### PR TITLE
[control] esphome 2025.11 changes action play api

### DIFF
--- a/esphome/components/media_proxy_control/automation.h
+++ b/esphome/components/media_proxy_control/automation.h
@@ -15,12 +15,21 @@ template<typename... Ts> class SetSourceAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(std::string, src)
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override {
+    std::string src = this->src_.value(x...);
+    if (output_) {
+      output_->set_src(src);
+    }
+  }
+#else
   void play(Ts... x) override {
     std::string src = this->src_.value(x...);
     if (output_) {
       output_->set_src(src);
     }
   }
+#endif
 
  protected:
   MediaProxyOutput* output_;
@@ -30,11 +39,19 @@ template<typename... Ts> class StartAction : public Action<Ts...> {
  public:
   StartAction(MediaProxyOutput* output) : output_(output) {}
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override {
+    if (output_) {
+      output_->start();
+    }
+  }
+#else
   void play(Ts... x) override {
     if (output_) {
       output_->start();
     }
   }
+#endif
 
  protected:
   MediaProxyOutput* output_;
@@ -44,11 +61,19 @@ template<typename... Ts> class StopAction : public Action<Ts...> {
  public:
   StopAction(MediaProxyOutput* output) : output_(output) {}
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override {
+    if (output_) {
+      output_->stop();
+    }
+  }
+#else
   void play(Ts... x) override {
     if (output_) {
       output_->stop();
     }
   }
+#endif
 
  protected:
   MediaProxyOutput* output_;


### PR DESCRIPTION
https://github.com/esphome/esphome/pull/11704 changes play() to use a const reference which will break all external components that use actions.