### PR TITLE
Use new App.wake_loop_threadsafe to lower rendering latency

### DIFF
--- a/esphome/components/ddp/__init__.py
+++ b/esphome/components/ddp/__init__.py
@@ -86,6 +86,14 @@ async def to_code(config):
     if config[CONF_METRICS]:
         cg.add_build_flag("-DDDP_METRICS")
 
+    # Enable wake_loop_threadsafe for low-latency wakeup (ESPHome 2025.11+)
+    try:
+        from esphome.components import socket
+        socket.require_wake_loop_threadsafe()
+    except AttributeError:
+        # Backward compatibility: not available in older ESPHome
+        pass
+
 
 # Register ddp_light_effect as an addressable light effect
 @register_addressable_effect(

--- a/esphome/components/ddp/ddp.cpp
+++ b/esphome/components/ddp/ddp.cpp
@@ -505,6 +505,11 @@ void DdpComponent::handle_push_(uint8_t stream_id, const DdpHeader* hdr) {
     this->enable_loop_soon_any_context();
   }
 
+  // Wake main loop immediately for low-latency frame presentation (ESPHome 2025.11+)
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+  App.wake_loop_threadsafe();
+#endif
+
 #if DDP_METRICS
   // Reset frame assembly state
   m.frame_seen_any = false;

--- a/esphome/components/ddp/ddp.cpp
+++ b/esphome/components/ddp/ddp.cpp
@@ -5,6 +5,7 @@
 
 #include "ddp.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include "esphome/components/network/util.h"
 #include <algorithm>
 #include <cstdio>


### PR DESCRIPTION
https://github.com/esphome/esphome/pull/11681 added a new feature in 2025.11 that can be used to lower latency from receiving a push to rendering, so lets use it.