### PR TITLE
Port to LVGL 9.5 and ESPHome 2026.4.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ddp-esphome
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![ESPHome](https://img.shields.io/badge/ESPHome-2025.8-blue)](https://esphome.io/)
+[![ESPHome](https://img.shields.io/badge/ESPHome-2026.4+-blue)](https://esphome.io/)
 [![ESP-IDF](https://img.shields.io/badge/ESP--IDF-5.x-orange)](https://docs.espressif.com/projects/esp-idf/)
 
 ESPHome external components for streaming images/video to **LVGL** displays and **AddressableLight** LED strips via **DDP** (Distributed Display Protocol) over UDP.
@@ -18,7 +18,7 @@ This repository provides a modular set of ESPHome components:
 - **`ddp_light_effect`**: AddressableLight effect for RGB/RGBW LED strips
 - **`media_proxy_control`**: WebSocket client for orchestrating media playback (images, videos, etc.) via the [media-proxy server](https://github.com/stuartparmenter/media-proxy)
 
-> Tested with **ESPHome 2025.8** (ESP-IDF only). Arduino is **not** supported.
+> Requires **ESPHome 2026.4.0 or newer** (which bundles LVGL 9.5). ESP-IDF only — Arduino is **not** supported.
 
 > **Note:** Legacy components `ddp_stream` and `ws_ddp_control` were removed in v0.7.0. Users on these components should use **v0.6.1** or earlier, or migrate to the new modular architecture. See examples for migration guidance.
 

--- a/esphome/components/ddp/__init__.py
+++ b/esphome/components/ddp/__init__.py
@@ -86,14 +86,6 @@ async def to_code(config):
     if config[CONF_METRICS]:
         cg.add_build_flag("-DDDP_METRICS")
 
-    # Enable wake_loop_threadsafe for low-latency wakeup (ESPHome 2025.11+)
-    try:
-        from esphome.components import socket
-        socket.require_wake_loop_threadsafe()
-    except AttributeError:
-        # Backward compatibility: not available in older ESPHome
-        pass
-
 
 # Register ddp_light_effect as an addressable light effect
 @register_addressable_effect(

--- a/esphome/components/ddp/ddp.cpp
+++ b/esphome/components/ddp/ddp.cpp
@@ -503,10 +503,8 @@ void DdpComponent::handle_push_(uint8_t stream_id, const DdpHeader* hdr) {
     this->enable_loop_soon_any_context();
   }
 
-  // Wake main loop immediately for low-latency frame presentation (ESPHome 2025.11+)
-#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+  // Wake main loop immediately for low-latency frame presentation
   App.wake_loop_threadsafe();
-#endif
 
 #if DDP_METRICS
   // Reset frame assembly state

--- a/esphome/components/ddp/ddp_pixel_convert.h
+++ b/esphome/components/ddp/ddp_pixel_convert.h
@@ -158,6 +158,80 @@ inline void convert_rgb888_to_rgb32(uint32_t *dst, const uint8_t *src, size_t pi
   }
 }
 
+// Convert RGB888 (R,G,B) to BGR888 (LVGL 24-bit mode: lv_color_t {blue, green, red})
+// Safe to call from UDP task (pure math, no allocations or API calls)
+//
+// dst: Destination buffer for BGR888 pixels (must be pre-allocated, 3 bytes per pixel)
+// src: Source RGB888 data (3 bytes per pixel: R, G, B)
+// pixel_count: Number of pixels to convert
+inline void convert_rgb888_to_bgr888(uint8_t *dst, const uint8_t *src, size_t pixel_count) noexcept {
+  if (!dst || !src)
+    return;
+
+  const uint8_t *sp = src;
+  uint8_t *dp = dst;
+
+  for (size_t i = 0; i < pixel_count; ++i) {
+    dp[0] = sp[2];  // B
+    dp[1] = sp[1];  // G
+    dp[2] = sp[0];  // R
+    sp += 3;
+    dp += 3;
+  }
+}
+
+// Convert RGB565 to BGR888 (LVGL 24-bit mode: lv_color_t {blue, green, red})
+// Safe to call from UDP task (pure math, no allocations or API calls)
+//
+// dst: Destination buffer for BGR888 pixels (must be pre-allocated, 3 bytes per pixel)
+// src: Source RGB565 data (2 bytes per pixel)
+// pixel_count: Number of pixels to convert
+// src_big_endian: If true, source is RGB565 big-endian; if false, little-endian
+inline void convert_rgb565_to_bgr888(uint8_t *dst, const uint8_t *src, size_t pixel_count, bool src_big_endian) noexcept {
+  if (!dst || !src)
+    return;
+
+  const uint8_t *sp = src;
+  uint8_t *dp = dst;
+
+  for (size_t i = 0; i < pixel_count; ++i) {
+    uint16_t v = src_big_endian ? (uint16_t)((sp[0] << 8) | sp[1])
+                                : (uint16_t)((sp[1] << 8) | sp[0]);
+    uint8_t r5 = (uint8_t)((v >> 11) & 0x1F);
+    uint8_t g6 = (uint8_t)((v >> 5) & 0x3F);
+    uint8_t b5 = (uint8_t)(v & 0x1F);
+
+    // Expand to 8-bit and store as BGR
+    dp[0] = (uint8_t)((b5 << 3) | (b5 >> 2));  // B
+    dp[1] = (uint8_t)((g6 << 2) | (g6 >> 4));  // G
+    dp[2] = (uint8_t)((r5 << 3) | (r5 >> 2));  // R
+    sp += 2;
+    dp += 3;
+  }
+}
+
+// Convert RGBW to BGR888 (LVGL 24-bit mode, drop W channel)
+// Safe to call from UDP task (pure math, no allocations or API calls)
+//
+// dst: Destination buffer for BGR888 pixels (must be pre-allocated, 3 bytes per pixel)
+// src: Source RGBW data (4 bytes per pixel: R, G, B, W)
+// pixel_count: Number of pixels to convert
+inline void convert_rgbw_to_bgr888(uint8_t *dst, const uint8_t *src, size_t pixel_count) noexcept {
+  if (!dst || !src)
+    return;
+
+  const uint8_t *sp = src;
+  uint8_t *dp = dst;
+
+  for (size_t i = 0; i < pixel_count; ++i) {
+    dp[0] = sp[2];  // B
+    dp[1] = sp[1];  // G
+    dp[2] = sp[0];  // R (W at sp[3] ignored)
+    sp += 4;
+    dp += 3;
+  }
+}
+
 // Convert RGBW to RGB565 (drop W channel) with optional byte swap
 // Safe to call from UDP task (pure math, no allocations or API calls)
 // Inline so it can be used across components without linkage issues

--- a/esphome/components/ddp_canvas/ddp_canvas.cpp
+++ b/esphome/components/ddp_canvas/ddp_canvas.cpp
@@ -96,30 +96,24 @@ void DdpCanvas::on_data(size_t offset_px, const uint8_t* pixels,
 #if LV_COLOR_DEPTH == 16
   uint16_t* dst = dst_buf + offset_px;
 
-  // LVGL 9 removed LV_COLOR_16_SWAP; canvas buffers use native byte order.
-  // Display drivers handle any byte swapping needed for hardware.
-  constexpr bool swap_bytes = false;
-
   if (format == PixelFormat::RGB888) {
-    // RGB888 → RGB565 (with optional byte swap)
-    convert_rgb888_to_rgb565(dst, pixels, pixel_count, swap_bytes);
+    // RGB888 → native RGB565 (no byte swap: LVGL 9 canvas uses native byte order)
+    convert_rgb888_to_rgb565(dst, pixels, pixel_count, false);
 
   } else if (format == PixelFormat::RGB565_BE || format == PixelFormat::RGB565_LE) {
-    // RGB565 → RGB565 (byte swap if endianness mismatch)
-    const bool src_be = (format == PixelFormat::RGB565_BE);
-
-    if (src_be == swap_bytes) {
-      // Direct copy
+    // RGB565 → native RGB565
+    if (format == PixelFormat::RGB565_LE) {
+      // Source is LE (native on ESP32) — direct copy
       std::memcpy(dst, pixels, pixel_count * 2);
     } else {
-      // Copy + byte swap
+      // Source is BE — copy + byte swap to native LE
       std::memcpy(dst, pixels, pixel_count * 2);
       swap_rgb565_bytes(dst, pixel_count);
     }
 
   } else if (format == PixelFormat::RGBW) {
-    // RGBW → RGB565 (drop W channel, with optional byte swap)
-    convert_rgbw_to_rgb565(dst, pixels, pixel_count, swap_bytes);
+    // RGBW → native RGB565 (drop W channel)
+    convert_rgbw_to_rgb565(dst, pixels, pixel_count, false);
   }
 
 #elif LV_COLOR_DEPTH == 32

--- a/esphome/components/ddp_canvas/ddp_canvas.cpp
+++ b/esphome/components/ddp_canvas/ddp_canvas.cpp
@@ -16,7 +16,8 @@ namespace ddp {
 static const char* TAG = "ddp.canvas";
 
 // LVGL assertions
-static_assert(LV_COLOR_DEPTH == 16 || LV_COLOR_DEPTH == 32, "LV_COLOR_DEPTH must be 16 or 32");
+static_assert(LV_COLOR_DEPTH == 16 || LV_COLOR_DEPTH == 24 || LV_COLOR_DEPTH == 32,
+              "LV_COLOR_DEPTH must be 16, 24, or 32");
 static constexpr size_t BYTES_PER_PIXEL = LV_COLOR_DEPTH / 8;
 
 static const char* color_format_name(lv_color_format_t cf) {
@@ -114,6 +115,24 @@ void DdpCanvas::on_data(size_t offset_px, const uint8_t* pixels,
   } else if (format == PixelFormat::RGBW) {
     // RGBW → native RGB565 (drop W channel)
     convert_rgbw_to_rgb565(dst, pixels, pixel_count, false);
+  }
+
+#elif LV_COLOR_DEPTH == 24
+  // LVGL 9 RGB888: lv_color_t is {blue, green, red} — BGR byte order
+  uint8_t* dst24 = reinterpret_cast<uint8_t*>(dst_buf) + offset_px * 3;
+
+  if (format == PixelFormat::RGB888) {
+    // RGB888 (R,G,B) → BGR888 (swap R↔B)
+    convert_rgb888_to_bgr888(dst24, pixels, pixel_count);
+
+  } else if (format == PixelFormat::RGB565_BE || format == PixelFormat::RGB565_LE) {
+    // RGB565 → BGR888 (expand + reorder)
+    const bool src_be = (format == PixelFormat::RGB565_BE);
+    convert_rgb565_to_bgr888(dst24, pixels, pixel_count, src_be);
+
+  } else if (format == PixelFormat::RGBW) {
+    // RGBW → BGR888 (drop W, swap R↔B)
+    convert_rgbw_to_bgr888(dst24, pixels, pixel_count);
   }
 
 #elif LV_COLOR_DEPTH == 32

--- a/esphome/components/ddp_canvas/ddp_canvas.cpp
+++ b/esphome/components/ddp_canvas/ddp_canvas.cpp
@@ -19,19 +19,22 @@ static const char* TAG = "ddp.canvas";
 static_assert(LV_COLOR_DEPTH == 16 || LV_COLOR_DEPTH == 32, "LV_COLOR_DEPTH must be 16 or 32");
 static constexpr size_t BYTES_PER_PIXEL = LV_COLOR_DEPTH / 8;
 
-static const char* img_cf_name(uint8_t cf) {
+static const char* color_format_name(lv_color_format_t cf) {
   switch (cf) {
-    case LV_IMG_CF_TRUE_COLOR:                  return "TRUE_COLOR";
-    case LV_IMG_CF_TRUE_COLOR_CHROMA_KEYED:     return "TRUE_COLOR_CK";
-    case LV_IMG_CF_TRUE_COLOR_ALPHA:            return "TRUE_COLOR_ALPHA";
-    case LV_IMG_CF_INDEXED_1BIT:                return "INDEXED_1BIT";
-    case LV_IMG_CF_INDEXED_2BIT:                return "INDEXED_2BIT";
-    case LV_IMG_CF_INDEXED_4BIT:                return "INDEXED_4BIT";
-    case LV_IMG_CF_INDEXED_8BIT:                return "INDEXED_8BIT";
-    case LV_IMG_CF_ALPHA_1BIT:                  return "ALPHA_1BIT";
-    case LV_IMG_CF_ALPHA_2BIT:                  return "ALPHA_2BIT";
-    case LV_IMG_CF_ALPHA_4BIT:                  return "ALPHA_4BIT";
-    case LV_IMG_CF_ALPHA_8BIT:                  return "ALPHA_8BIT";
+    case LV_COLOR_FORMAT_RGB565:                return "RGB565";
+    case LV_COLOR_FORMAT_RGB888:                return "RGB888";
+    case LV_COLOR_FORMAT_ARGB8888:              return "ARGB8888";
+    case LV_COLOR_FORMAT_XRGB8888:              return "XRGB8888";
+    case LV_COLOR_FORMAT_ARGB8565:              return "ARGB8565";
+    case LV_COLOR_FORMAT_I1:                    return "I1";
+    case LV_COLOR_FORMAT_I2:                    return "I2";
+    case LV_COLOR_FORMAT_I4:                    return "I4";
+    case LV_COLOR_FORMAT_I8:                    return "I8";
+    case LV_COLOR_FORMAT_A1:                    return "A1";
+    case LV_COLOR_FORMAT_A2:                    return "A2";
+    case LV_COLOR_FORMAT_A4:                    return "A4";
+    case LV_COLOR_FORMAT_A8:                    return "A8";
+    case LV_COLOR_FORMAT_L8:                    return "L8";
     default:                                    return "UNKNOWN";
   }
 }
@@ -93,13 +96,9 @@ void DdpCanvas::on_data(size_t offset_px, const uint8_t* pixels,
 #if LV_COLOR_DEPTH == 16
   uint16_t* dst = dst_buf + offset_px;
 
-  // Determine byte swap requirement once (used by RGB888 and RGBW conversions)
-  constexpr bool swap_bytes =
-  #if defined(LV_COLOR_16_SWAP) && LV_COLOR_16_SWAP
-      true;
-  #else
-      false;
-  #endif
+  // LVGL 9 removed LV_COLOR_16_SWAP; canvas buffers use native byte order.
+  // Display drivers handle any byte swapping needed for hardware.
+  constexpr bool swap_bytes = false;
 
   if (format == PixelFormat::RGB888) {
     // RGB888 → RGB565 (with optional byte swap)
@@ -360,26 +359,26 @@ void DdpCanvas::ensure_buffers_() {
   if (!canvas_) return;
 
   // Adopt the canvas' existing buffer as our front (owned by LVGL canvas)
-  auto* img = (lv_img_dsc_t*)lv_canvas_get_img(canvas_);
-  if (!img || !img->data || img->header.w <= 0 || img->header.h <= 0) {
+  auto* draw_buf = lv_canvas_get_draw_buf(canvas_);
+  if (!draw_buf || !draw_buf->data || draw_buf->header.w <= 0 || draw_buf->header.h <= 0) {
     // Canvas not fully initialized yet
     return;
   }
 
-  const size_t px = (size_t)img->header.w * (size_t)img->header.h;
+  const size_t px = (size_t)draw_buf->header.w * (size_t)draw_buf->header.h;
 
   // Log whenever the canvas buffer pointer changes or size changes
-  if (front_buf_ != (uint16_t*)img->data || buf_px_ != px) {
+  if (front_buf_ != (uint16_t*)draw_buf->data || buf_px_ != px) {
     ESP_LOGI(TAG,
-      "Using canvas buffer: cv=%p img=%p data=%p w=%d h=%d cf=%u(%s) LV_COLOR_DEPTH=%d buf_px(old=%u -> new=%u)",
-      (void*)canvas_, (void*)img, (void*)img->data,
-      (int)img->header.w, (int)img->header.h,
-      (unsigned)img->header.cf, img_cf_name(img->header.cf),
+      "Using canvas draw_buf: cv=%p buf=%p data=%p w=%d h=%d cf=%u(%s) LV_COLOR_DEPTH=%d buf_px(old=%u -> new=%u)",
+      (void*)canvas_, (void*)draw_buf, (void*)draw_buf->data,
+      (int)draw_buf->header.w, (int)draw_buf->header.h,
+      (unsigned)draw_buf->header.cf, color_format_name((lv_color_format_t)draw_buf->header.cf),
       (int)LV_COLOR_DEPTH,
       (unsigned)buf_px_, (unsigned)px);
   }
 
-  front_buf_ = (uint16_t*)img->data;
+  front_buf_ = (uint16_t*)draw_buf->data;
 
   // (Re)allocate only ready/accum when size changes
   if (buf_px_ != px) {
@@ -391,7 +390,7 @@ void DdpCanvas::ensure_buffers_() {
 
   // Allocate ready buffer (triple-buffer mode)
   if (back_buffers_ == 2 && !ready_buf_) {
-    ready_buf_ = static_cast<uint16_t*>(lv_mem_alloc(bytes));
+    ready_buf_ = static_cast<uint16_t*>(lv_malloc(bytes));
     if (!ready_buf_) {
       free_ready_accum_();
       buf_px_ = 0;
@@ -402,7 +401,7 @@ void DdpCanvas::ensure_buffers_() {
 
   // Allocate accum buffer (double or triple-buffer mode)
   if ((back_buffers_ >= 1) && !accum_buf_) {
-    accum_buf_ = static_cast<uint16_t*>(lv_mem_alloc(bytes));
+    accum_buf_ = static_cast<uint16_t*>(lv_malloc(bytes));
     if (!accum_buf_) {
       free_ready_accum_();
       buf_px_ = 0;
@@ -413,29 +412,29 @@ void DdpCanvas::ensure_buffers_() {
 
   // Free extra buffers if mode changed
   if (back_buffers_ < 2 && ready_buf_) {
-    lv_mem_free(ready_buf_);
+    lv_free(ready_buf_);
     ready_buf_ = nullptr;
   }
   if (back_buffers_ < 1 && accum_buf_) {
-    lv_mem_free(accum_buf_);
+    lv_free(accum_buf_);
     accum_buf_ = nullptr;
   }
 }
 
 void DdpCanvas::free_ready_accum_() {
   if (ready_buf_) {
-    lv_mem_free(ready_buf_);
+    lv_free(ready_buf_);
     ready_buf_ = nullptr;
   }
   if (accum_buf_) {
-    lv_mem_free(accum_buf_);
+    lv_free(accum_buf_);
     accum_buf_ = nullptr;
   }
   have_ready_.store(false);
 }
 
 void DdpCanvas::on_canvas_size_changed_(lv_event_t* e) {
-  auto* canvas = lv_event_get_target(e);
+  auto* canvas = lv_event_get_target_obj(e);
   auto* self = static_cast<DdpCanvas*>(lv_event_get_user_data(e));
   if (!self || !canvas || canvas != self->canvas_) return;
 

--- a/esphome/components/media_proxy_control/__init__.py
+++ b/esphome/components/media_proxy_control/__init__.py
@@ -102,6 +102,7 @@ StopAction = media_proxy_ns.class_("StopAction", automation.Action)
             cv.Required(CONF_SRC): cv.templatable(cv.string),
         }
     ),
+    synchronous=True,
 )
 async def set_source_action_to_code(config, action_id, template_arg, args):
     output = await cg.get_variable(config[CONF_ID])
@@ -119,6 +120,7 @@ async def set_source_action_to_code(config, action_id, template_arg, args):
             cv.GenerateID(CONF_ID): cv.use_id(MediaProxyOutput),
         }
     ),
+    synchronous=True,
 )
 async def start_action_to_code(config, action_id, template_arg, args):
     output = await cg.get_variable(config[CONF_ID])
@@ -134,6 +136,7 @@ async def start_action_to_code(config, action_id, template_arg, args):
             cv.GenerateID(CONF_ID): cv.use_id(MediaProxyOutput),
         }
     ),
+    synchronous=True,
 )
 async def stop_action_to_code(config, action_id, template_arg, args):
     output = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/media_proxy_control/media_proxy_control.cpp
+++ b/esphome/components/media_proxy_control/media_proxy_control.cpp
@@ -184,7 +184,7 @@ static void log_stream_line_(const char *label,
 }
 
 // map format string -> ("fmt" field, pixcfg byte). For "rgb565" without endian,
-// we borrow endianness from the sink's LVGL (preferred_ddp_pixcfg()).
+// use platform byte order (LVGL 9 removed LV_COLOR_16_SWAP; canvas uses native order).
 static inline std::pair<std::string,uint8_t>
 resolve_fmt_and_pixcfg_(const std::string &fmt_in, ddp::DdpComponent *ddp) {
   std::string f = fmt_in;
@@ -198,7 +198,7 @@ resolve_fmt_and_pixcfg_(const std::string &fmt_in, ddp::DdpComponent *ddp) {
   if (f == "rgbw")
     return { "rgbw", ddp::DDP_PIXCFG_RGBW };
   if (f == "rgb565") {
-#if defined(LV_COLOR_16_SWAP) && LV_COLOR_16_SWAP
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     return { "rgb565be", ddp::DDP_PIXCFG_RGB565_BE };
 #else
     return { "rgb565le", ddp::DDP_PIXCFG_RGB565_LE };


### PR DESCRIPTION
## Summary

Port LVGL-using code to LVGL 9.5 and update the Python side for ESPHome 2026.4.0.

## LVGL 9.5 port

- **Canvas buffer access**: `lv_img_dsc_t`/`lv_canvas_get_img()` → `lv_draw_buf_t`/`lv_canvas_get_draw_buf()`
- **Memory management**: `lv_mem_alloc`/`lv_mem_free` → `lv_malloc`/`lv_free`
- **Event handling**: `lv_event_get_target()` → `lv_event_get_target_obj()`
- **Color format constants**: `LV_IMG_CF_*` → `LV_COLOR_FORMAT_*`
- **Byte swap removal**: `LV_COLOR_16_SWAP` is gone in LVGL 9 — canvas buffers use native byte order; display drivers handle hardware byte swapping
- **Endianness detection**: `media_proxy_control` now uses `__BYTE_ORDER__` instead of `LV_COLOR_16_SWAP` for RGB565 endianness

## ESPHome 2026.4.0 compatibility

- **Wake loop deprecation**: drop the `socket.require_wake_loop_threadsafe()` call and the `USE_SOCKET_SELECT_SUPPORT`/`USE_WAKE_LOOP_THREADSAFE` `#ifdef` guards around `App.wake_loop_threadsafe()`. Wake loop support is now always available.
- **Synchronous action registration**: add `synchronous=True` to `media_proxy_control.set_source`/`start`/`stop`. Each action's `play()` invokes the output target synchronously, so the non-owning StringRef optimization for trigger args is safe.
- **README**: bump requirement to ESPHome 2026.4.0 or newer (bundles LVGL 9.5).

## Test plan

- [ ] Build with ESPHome 2026.4.0+ targeting an ESP32 with a display
- [ ] Verify DDP canvas streaming works with RGB888 input
- [ ] Verify DDP canvas streaming works with RGB565 input
- [ ] Verify canvas diagnostic logging shows correct color format names
- [ ] Test media_proxy_control actions fired from a trigger with string args (wizmote / template select)