### PR TITLE
ci(actions): pin to SHAs and update release-drafter to v7

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,15 +15,15 @@ jobs:
     environment: release-drafter
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
         id: drafter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Update version files
         run: |


### PR DESCRIPTION
## Summary

- Pin all third-party actions in `.github/workflows/release-drafter.yml` to commit SHAs with trailing version comments (Dependabot-compatible). Tag references like `@v6` are mutable — pinning to immutable SHAs hardens against tag-hijack and compromised-maintainer supply-chain attacks.
- Update `release-drafter/release-drafter` v6 → **v7.2.0**. v7 dropped the `GITHUB_TOKEN` env-var pattern in favor of a `token` input, so the token is now passed via `with: token:`. (See [v7 action.yml](https://github.com/release-drafter/release-drafter/blob/v7.2.0/action.yml) — defaults to `${{ github.token }}`, but we keep the explicit `secrets.GITHUB_TOKEN` reference to mirror prior behavior.)
- Update `astral-sh/setup-uv` v7 → **v8.0.0**. v8 [removed all major/minor floating tags](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) (citing the tj-actions supply-chain incident) and only ships immutable releases — so `@v8` no longer resolves and SHA pinning is now mandatory. The v8 breaking change around `manifest-file` does not affect this workflow (no custom manifest used).

### Pinned versions

| Action | Old | New | SHA |
| --- | --- | --- | --- |
| `release-drafter/release-drafter` | `@v6` | v7.2.0 | `5de93583980a40bd78603b6dfdcda5b4df377b32` |
| `actions/checkout` | `@v6` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `astral-sh/setup-uv` | `@v7` | v8.0.0 | `cec208311dfd045dd5311c1add060b2062131d57` |

Dependabot's existing `github-actions` group config in `.github/dependabot.yml` will continue to bump these — it understands the trailing `# v7.2.0` style comments and updates SHA + comment together.

## Test plan

- [ ] CI passes on this branch (no workflows trigger off PRs in this repo, but YAML syntax is the main concern — `actionlint` would catch any issue)
- [ ] After merge to `main`, the next push triggers `Release Drafter` and the v7 action runs successfully with the new `with: token:` input
- [ ] Verify the draft release on GitHub still updates correctly and that `setup-uv@v8` installs uv without error in the lockfile-regen step